### PR TITLE
Create a NavigatorPanel that shows the @RequestMappings for the current controller

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,16 @@
             <version>${netbeans.api.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-netbeans-modules-java-source</artifactId>
+            <version>${netbeans.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-netbeans-modules-java-source-base</artifactId>
+            <version>${netbeans.api.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.netbeans.contrib.yenta</groupId>
             <artifactId>api</artifactId>
             <version>1.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,11 @@
             <version>${netbeans.api.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-netbeans-spi-navigator</artifactId>
+            <version>${netbeans.api.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.netbeans.contrib.yenta</groupId>
             <artifactId>api</artifactId>
             <version>1.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,16 @@
             <version>${netbeans.api.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-netbeans-modules-java-sourceui</artifactId>
+            <version>${netbeans.api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-text</artifactId>
+            <version>${netbeans.api.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.netbeans.contrib.yenta</groupId>
             <artifactId>api</artifactId>
             <version>1.1</version>

--- a/src/main/java/com/github/alexfalappa/nbspringboot/navigator/ElementScanningTaskFactory.java
+++ b/src/main/java/com/github/alexfalappa/nbspringboot/navigator/ElementScanningTaskFactory.java
@@ -17,9 +17,6 @@ package com.github.alexfalappa.nbspringboot.navigator;
 
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.util.TreePath;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
 import org.netbeans.api.java.source.CancellableTask;
 import org.netbeans.api.java.source.CompilationInfo;
 import org.netbeans.api.java.source.JavaSource;
@@ -69,25 +66,7 @@ public class ElementScanningTaskFactory extends LookupBasedJavaSourceTaskFactory
             final TreePath rootPath = new TreePath(compilationUnitTree);
 
             this.mappedElementExtractor = new MappedElementExtractor(p.getFileObject(), compilationUnitTree, p.getTrees(), rootPath);
-            final List<MappedElement> mappedElements = compilationUnitTree.accept(this.mappedElementExtractor, null);
-            Collections.sort(mappedElements, new Comparator<MappedElement>() {
-                @Override
-                public int compare(MappedElement o1, MappedElement o2) {
-                    int rv = o1.getResourceUrl().compareTo(o2.getResourceUrl());
-                    if (rv == 0) {
-                        if (o1.getRequestMethod() == null) {
-                            rv = -1;
-                        } else if (o2.getRequestMethod() == null) {
-                            rv = 1;
-                        } else {
-                            rv = o1.getRequestMethod().compareTo(o2.getRequestMethod());
-                        }
-
-                    }
-                    return rv;
-                }
-            });
-            this.targetModel.refresh(mappedElements);
+            this.targetModel.refresh(compilationUnitTree.accept(this.mappedElementExtractor, null));
         }
     }
 

--- a/src/main/java/com/github/alexfalappa/nbspringboot/navigator/ElementScanningTaskFactory.java
+++ b/src/main/java/com/github/alexfalappa/nbspringboot/navigator/ElementScanningTaskFactory.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.alexfalappa.nbspringboot.navigator;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.util.TreePath;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import org.netbeans.api.java.source.CancellableTask;
+import org.netbeans.api.java.source.CompilationInfo;
+import org.netbeans.api.java.source.JavaSource;
+import org.netbeans.api.java.source.support.LookupBasedJavaSourceTaskFactory;
+import org.openide.filesystems.FileObject;
+import org.openide.util.Lookup;
+import org.openide.util.Utilities;
+
+/**
+ * This factory triggers the scanning of compilation units. If it is active, it
+ * uses the {@link ElementScanningTask}, otherwise an empty task.
+ *
+ * @author Michael J. Simons, 2016-09-16
+ */
+public class ElementScanningTaskFactory extends LookupBasedJavaSourceTaskFactory {
+
+    /**
+     * This task uses the {@link MappedElementExtractor} to scan the current
+     * compilation unit for mapped elements.
+     *
+     * @author Michael J. Simons, 2016-09-16
+     */
+    static class ElementScanningTask implements CancellableTask<CompilationInfo> {
+
+        private final MappedElementsModel targetModel;
+        private MappedElementExtractor mappedElementExtractor;
+        private volatile boolean canceled;
+
+        public ElementScanningTask(MappedElementsModel targetModel) {
+            this.targetModel = targetModel;
+        }
+
+        @Override
+        public void cancel() {
+            this.canceled = true;
+            if (this.mappedElementExtractor != null) {
+                this.mappedElementExtractor.cancel();
+                this.mappedElementExtractor = null;
+            }
+        }
+
+        @Override
+        public void run(CompilationInfo p) throws Exception {
+            this.canceled = false;
+
+            final CompilationUnitTree compilationUnitTree = p.getCompilationUnit();
+            final TreePath rootPath = new TreePath(compilationUnitTree);
+
+            this.mappedElementExtractor = new MappedElementExtractor(compilationUnitTree, p.getTrees(), rootPath);
+            final List<MappedElement> mappedElements = compilationUnitTree.accept(this.mappedElementExtractor, null);
+            Collections.sort(mappedElements, new Comparator<MappedElement>() {
+                @Override
+                public int compare(MappedElement o1, MappedElement o2) {
+                    int rv = o1.getUrl().compareTo(o2.getUrl());
+                    if (rv == 0) {
+                        if (o1.getMethod() == null) {
+                            rv = -1;
+                        } else if (o2.getMethod() == null) {
+                            rv = 1;
+                        } else {
+                            rv = o1.getMethod().compareTo(o2.getMethod());
+                        }
+
+                    }
+                    return rv;
+                }
+            });
+            this.targetModel.refresh(mappedElements);
+        }
+    }
+
+    private final CancellableTask<CompilationInfo> EMPTY_TASK = new CancellableTask<CompilationInfo>() {
+        @Override
+        public void cancel() {
+        }
+
+        @Override
+        public void run(CompilationInfo parameter) throws Exception {
+        }
+    };
+
+    private final MappedElementsModel mappedElementsModel;
+    private volatile boolean active = false;
+
+    public ElementScanningTaskFactory(final MappedElementsModel mappedElementsModel) {
+        super(JavaSource.Phase.PARSED, JavaSource.Priority.NORMAL);
+        this.mappedElementsModel = mappedElementsModel;
+    }
+
+    public void activate() {
+        this.active = true;
+        this.setLookup(Utilities.actionsGlobalContext());
+    }
+
+    public void deactivate() {
+        this.active = false;
+        this.setLookup(Lookup.EMPTY);
+    }
+
+    @Override
+    protected CancellableTask<CompilationInfo> createTask(final FileObject fo) {
+        return this.active ? new ElementScanningTask(this.mappedElementsModel) : EMPTY_TASK;
+    }
+}

--- a/src/main/java/com/github/alexfalappa/nbspringboot/navigator/ElementScanningTaskFactory.java
+++ b/src/main/java/com/github/alexfalappa/nbspringboot/navigator/ElementScanningTaskFactory.java
@@ -68,19 +68,19 @@ public class ElementScanningTaskFactory extends LookupBasedJavaSourceTaskFactory
             final CompilationUnitTree compilationUnitTree = p.getCompilationUnit();
             final TreePath rootPath = new TreePath(compilationUnitTree);
 
-            this.mappedElementExtractor = new MappedElementExtractor(compilationUnitTree, p.getTrees(), rootPath);
+            this.mappedElementExtractor = new MappedElementExtractor(p.getFileObject(), compilationUnitTree, p.getTrees(), rootPath);
             final List<MappedElement> mappedElements = compilationUnitTree.accept(this.mappedElementExtractor, null);
             Collections.sort(mappedElements, new Comparator<MappedElement>() {
                 @Override
                 public int compare(MappedElement o1, MappedElement o2) {
-                    int rv = o1.getUrl().compareTo(o2.getUrl());
+                    int rv = o1.getResourceUrl().compareTo(o2.getResourceUrl());
                     if (rv == 0) {
-                        if (o1.getMethod() == null) {
+                        if (o1.getRequestMethod() == null) {
                             rv = -1;
-                        } else if (o2.getMethod() == null) {
+                        } else if (o2.getRequestMethod() == null) {
                             rv = 1;
                         } else {
-                            rv = o1.getMethod().compareTo(o2.getMethod());
+                            rv = o1.getRequestMethod().compareTo(o2.getRequestMethod());
                         }
 
                     }

--- a/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElement.java
+++ b/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElement.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.alexfalappa.nbspringboot.navigator;
+
+import javax.lang.model.element.Element;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+/**
+ * This is a source code element of kind METHOD which is mapped by
+ * {@code @RequestMapping} or derivations thereof.
+ *
+ * @author Michael J. Simons, 2016-09-16
+ */
+public final class MappedElement {
+
+    private final Element element;
+
+    private final String url;
+
+    private final RequestMethod method;
+
+    public MappedElement(Element element, String url, RequestMethod method) {
+        this.element = element;
+        this.url = url;
+        this.method = method;
+    }
+
+    public Element getElement() {
+        return element;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public RequestMethod getMethod() {
+        return method;
+    }
+}

--- a/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElement.java
+++ b/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElement.java
@@ -16,6 +16,8 @@
 package com.github.alexfalappa.nbspringboot.navigator;
 
 import javax.lang.model.element.Element;
+import org.netbeans.api.java.source.ElementHandle;
+import org.openide.filesystems.FileObject;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 /**
@@ -26,27 +28,41 @@ import org.springframework.web.bind.annotation.RequestMethod;
  */
 public final class MappedElement {
 
-    private final Element element;
+    private final FileObject fileObject;
+    
+    private final ElementHandle<Element> handle;
 
-    private final String url;
+    private final String handlerMethod;
+    
+    private final String resourceUrl;
 
-    private final RequestMethod method;
+    private final RequestMethod requestMethod;       
 
-    public MappedElement(Element element, String url, RequestMethod method) {
-        this.element = element;
-        this.url = url;
-        this.method = method;
+    public MappedElement(final FileObject fileObject, final Element element, final String url, final RequestMethod method) {
+        this.fileObject = fileObject;
+        this.handle = ElementHandle.create(element);
+        this.handlerMethod = element.toString();        
+        this.resourceUrl = url;
+        this.requestMethod = method;
     }
 
-    public Element getElement() {
-        return element;
+    public FileObject getFileObject() {
+        return fileObject;
+    }
+    
+    public ElementHandle<Element> getHandle() {
+        return handle;
     }
 
-    public String getUrl() {
-        return url;
+    public String getHandlerMethod() {
+        return handlerMethod;
+    }
+    
+    public String getResourceUrl() {
+        return resourceUrl;
     }
 
-    public RequestMethod getMethod() {
-        return method;
+    public RequestMethod getRequestMethod() {
+        return requestMethod;
     }
 }

--- a/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementExtractor.java
+++ b/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementExtractor.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.alexfalappa.nbspringboot.navigator;
+
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreeScanner;
+import com.sun.source.util.Trees;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import org.springframework.stereotype.Controller;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.PathMatcher;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * This scanner does the heavy lifting of extracting methods that have been
+ * mapped to URLs.
+ *
+ * I reassambled the Spring way as much at is possible without firing up a
+ * context: {@link RequestMapping} at type level does - if present - restrict
+ * all other mappings.
+ *
+ * @author Michael J. Simons, 2016-09-16
+ */
+public final class MappedElementExtractor extends TreeScanner<List<MappedElement>, Void> {
+
+    /**
+     * Needed for combining paths... I'd rather resort to the Spring facilities
+     * then do this my own.
+     */
+    private final PathMatcher pathMatcher = new AntPathMatcher();
+    private final CompilationUnitTree compilationUnitTree;
+    private final Trees trees;
+    private final TreePath rootPath;
+    private volatile boolean canceled = false;
+
+    public MappedElementExtractor(CompilationUnitTree compilationUnitTree, Trees trees, TreePath rootPath) {
+        this.compilationUnitTree = compilationUnitTree;
+        this.trees = trees;
+        this.rootPath = rootPath;
+    }
+
+    @Override
+    public List<MappedElement> reduce(final List<MappedElement> r1, final List<MappedElement> r2) {
+        final List<MappedElement> rv = new ArrayList<>();
+        if (r1 != null) {
+            rv.addAll(r1);
+        }
+        if (r2 != null) {
+            rv.addAll(r2);
+        }
+        return rv;
+    }
+
+    @Override
+    public List visitClass(final ClassTree node, final Void p) {
+        final List<MappedElement> mappedElements = new ArrayList<>();
+        if (canceled || node == null) {
+            return mappedElements;
+        }
+
+        final Element clazz = trees.getElement(new TreePath(rootPath, node));
+        if (clazz == null || (clazz.getAnnotation(Controller.class) == null && clazz.getAnnotation(RestController.class) == null)) {
+            return mappedElements;
+        }
+
+        final RequestMapping parentRequestMapping = clazz.getAnnotation(RequestMapping.class);
+        final Map<String, List<RequestMethod>> parentUrls = extractTypeLevelMappings(parentRequestMapping);
+
+        for (Element enclosedElement : clazz.getEnclosedElements()) {
+            if (enclosedElement.getKind() != ElementKind.METHOD) {
+                continue;
+            }
+            final Map<String, List<RequestMethod>> elementUrls = new TreeMap<>();
+            final RequestMapping requestMapping = enclosedElement.getAnnotation(RequestMapping.class);
+            if (requestMapping != null) {
+                extractMethodLevelMappings(elementUrls, concatValues(requestMapping.value(), requestMapping.path()), requestMapping.method());
+            }
+            final DeleteMapping deleteMapping = enclosedElement.getAnnotation(DeleteMapping.class);
+            if (deleteMapping != null) {
+                extractMethodLevelMappings(elementUrls, concatValues(deleteMapping.value(), deleteMapping.path()), new RequestMethod[]{RequestMethod.DELETE});
+            }
+            final GetMapping getMapping = enclosedElement.getAnnotation(GetMapping.class);
+            if (getMapping != null) {
+                extractMethodLevelMappings(elementUrls, concatValues(getMapping.value(), getMapping.path()), new RequestMethod[]{RequestMethod.GET});
+            }
+            final PatchMapping patchMapping = enclosedElement.getAnnotation(PatchMapping.class);
+            if (patchMapping != null) {
+                extractMethodLevelMappings(elementUrls, concatValues(patchMapping.value(), patchMapping.path()), new RequestMethod[]{RequestMethod.PATCH});
+            }
+            final PostMapping postMapping = enclosedElement.getAnnotation(PostMapping.class);
+            if (postMapping != null) {
+                extractMethodLevelMappings(elementUrls, concatValues(postMapping.value(), postMapping.path()), new RequestMethod[]{RequestMethod.POST});
+            }
+            final PutMapping putMapping = enclosedElement.getAnnotation(PutMapping.class);
+            if (putMapping != null) {
+                extractMethodLevelMappings(elementUrls, concatValues(putMapping.value(), putMapping.path()), new RequestMethod[]{RequestMethod.PUT});
+            }
+
+            for (Map.Entry<String, List<RequestMethod>> methodLevelMapping : elementUrls.entrySet()) {
+                for (Map.Entry<String, List<RequestMethod>> typeLevelMapping : parentUrls.entrySet()) {
+                    final String url = pathMatcher.combine(typeLevelMapping.getKey(), methodLevelMapping.getKey());
+
+                    final List<RequestMethod> effectiveMethods = new ArrayList<>();
+                    if (methodLevelMapping.getValue().isEmpty()) {
+                        effectiveMethods.add(null);
+                    }
+                    effectiveMethods.addAll(methodLevelMapping.getValue());
+                    if (!typeLevelMapping.getValue().isEmpty()) {
+                        effectiveMethods.retainAll(typeLevelMapping.getValue());
+                    }
+
+                    for (RequestMethod effectiveMethod : effectiveMethods) {
+                        mappedElements.add(new MappedElement(enclosedElement, url, effectiveMethod));
+                    }
+                }
+            }
+        }
+        return mappedElements;
+    }
+
+    void cancel() {
+        this.canceled = true;
+    }
+
+    /**
+     * Helper for concatenating several arrays.
+     *
+     * @param <T>
+     * @param data
+     * @return A list with the elements of the arrays in <code>data</code>
+     * concatenated
+     */
+    <T> List<T> concatValues(final T[]... data) {
+        final List<T> rv = new ArrayList<>();
+        for (T[] values : data) {
+            rv.addAll(Arrays.asList(values));
+        }
+        return rv;
+    }
+
+    /**
+     * Extracts the type level mapping if any. Makes sure that at least "/" is
+     * mapped and restricted to the given methods, if there any.
+     *
+     * @param parentRequestMapping
+     * @return
+     */
+    Map<String, List<RequestMethod>> extractTypeLevelMappings(final RequestMapping parentRequestMapping) {
+        final Map<String, List<RequestMethod>> parentUrls = new TreeMap<>();
+
+        List<String> urls = new ArrayList<>();
+        List<RequestMethod> methods = new ArrayList<>();
+        if (parentRequestMapping != null) {
+            urls = concatValues(parentRequestMapping.value(), parentRequestMapping.path());
+            methods = Arrays.asList(parentRequestMapping.method());
+        }
+
+        final List<String> usedUrls = urls.isEmpty() ? Arrays.asList("/") : urls;
+        for (final String url : usedUrls) {
+            final String usedUrl = url.startsWith("/") ? url : "/" + url;
+            parentUrls.put(usedUrl, methods);
+        }
+        return parentUrls;
+    }
+
+    /**
+     * Extracts the method level mapping.
+     *
+     * @param target
+     * @param urls
+     * @param methods
+     */
+    void extractMethodLevelMappings(final Map<String, List<RequestMethod>> target, final List<String> urls, final RequestMethod[] methods) {
+        final List<String> usedUrls = urls.isEmpty() ? Arrays.asList("/") : urls;
+        for (String url : usedUrls) {
+            final String usedUrl = url.startsWith("/") ? url : "/" + url;
+            final List<RequestMethod> mappedMethods;
+            if (target.containsKey(usedUrl)) {
+                mappedMethods = target.get(usedUrl);
+            } else {
+                mappedMethods = new ArrayList<>();
+                target.put(usedUrl, mappedMethods);
+            }
+            mappedMethods.addAll(Arrays.asList(methods));
+        }
+    }
+}

--- a/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementExtractor.java
+++ b/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementExtractor.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
+import org.openide.filesystems.FileObject;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
@@ -56,17 +57,19 @@ public final class MappedElementExtractor extends TreeScanner<List<MappedElement
      * then do this my own.
      */
     private final PathMatcher pathMatcher = new AntPathMatcher();
+    private final FileObject fileObject;
     private final CompilationUnitTree compilationUnitTree;
     private final Trees trees;
     private final TreePath rootPath;
-    private volatile boolean canceled = false;
+    private volatile boolean canceled = false;    
 
-    public MappedElementExtractor(CompilationUnitTree compilationUnitTree, Trees trees, TreePath rootPath) {
+    public MappedElementExtractor(final FileObject fileObject, final CompilationUnitTree compilationUnitTree, final Trees trees, final  TreePath rootPath) {
+        this.fileObject = fileObject;
         this.compilationUnitTree = compilationUnitTree;
         this.trees = trees;
         this.rootPath = rootPath;
     }
-
+    
     @Override
     public List<MappedElement> reduce(final List<MappedElement> r1, final List<MappedElement> r2) {
         final List<MappedElement> rv = new ArrayList<>();
@@ -138,7 +141,7 @@ public final class MappedElementExtractor extends TreeScanner<List<MappedElement
                     }
 
                     for (RequestMethod effectiveMethod : effectiveMethods) {
-                        mappedElements.add(new MappedElement(enclosedElement, url, effectiveMethod));
+                        mappedElements.add(new MappedElement(this.fileObject, enclosedElement, url, effectiveMethod));
                     }
                 }
             }

--- a/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementsModel.java
+++ b/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementsModel.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import javax.swing.SwingUtilities;
 import javax.swing.table.AbstractTableModel;
 
 /**
@@ -82,26 +83,31 @@ public class MappedElementsModel extends AbstractTableModel {
         return rv;
     }
 
-    void refresh(final List<MappedElement> newData) {        
-        this.data.clear();
-        this.data.addAll(newData);
-        Collections.sort(this.data, new Comparator<MappedElement>() {
+    void refresh(final List<MappedElement> newData) {
+        final Runnable r = new Runnable() {
             @Override
-            public int compare(MappedElement o1, MappedElement o2) {
-                int rv = o1.getResourceUrl().compareTo(o2.getResourceUrl());
-                if (rv == 0) {
-                    if (o1.getRequestMethod()== null) {
-                        rv = -1;
-                    } else if (o2.getRequestMethod() == null) {
-                        rv = 1;
-                    } else {
-                        rv = o1.getRequestMethod().compareTo(o2.getRequestMethod());
+            public void run() {
+                data.clear();
+                data.addAll(newData);
+                Collections.sort(data, new Comparator<MappedElement>() {
+                    @Override
+                    public int compare(MappedElement o1, MappedElement o2) {
+                        int rv = o1.getResourceUrl().compareTo(o2.getResourceUrl());
+                        if (rv == 0) {
+                            if (o1.getRequestMethod() == null) {
+                                rv = -1;
+                            } else if (o2.getRequestMethod() == null) {
+                                rv = 1;
+                            } else {
+                                rv = o1.getRequestMethod().compareTo(o2.getRequestMethod());
+                            }
+                        }
+                        return rv;
                     }
-
-                }
-                return rv;
+                });
+                fireTableDataChanged();
             }
-        });
-        this.fireTableDataChanged();
+        };
+        SwingUtilities.invokeLater(r);
     }
 }

--- a/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementsModel.java
+++ b/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementsModel.java
@@ -36,13 +36,13 @@ public class MappedElementsModel extends AbstractTableModel {
         String rv;
         switch (column) {
             case 0:
-                rv = "Resource URL";
+                rv = Bundle.resourceUrl();
                 break;
             case 1:
-                rv = "Request Method";
+                rv = Bundle.requestMethod();
                 break;
             case 2:
-                rv = "Handler Method";
+                rv = Bundle.handlerMethod();
                 break;
             default:
                 rv = null;

--- a/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementsModel.java
+++ b/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementsModel.java
@@ -17,6 +17,7 @@ package com.github.alexfalappa.nbspringboot.navigator;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import javax.swing.table.AbstractTableModel;
 
@@ -81,9 +82,26 @@ public class MappedElementsModel extends AbstractTableModel {
         return rv;
     }
 
-    void refresh(final List<MappedElement> newData) {
+    void refresh(final List<MappedElement> newData) {        
         this.data.clear();
         this.data.addAll(newData);
+        Collections.sort(this.data, new Comparator<MappedElement>() {
+            @Override
+            public int compare(MappedElement o1, MappedElement o2) {
+                int rv = o1.getResourceUrl().compareTo(o2.getResourceUrl());
+                if (rv == 0) {
+                    if (o1.getRequestMethod()== null) {
+                        rv = -1;
+                    } else if (o2.getRequestMethod() == null) {
+                        rv = 1;
+                    } else {
+                        rv = o1.getRequestMethod().compareTo(o2.getRequestMethod());
+                    }
+
+                }
+                return rv;
+            }
+        });
         this.fireTableDataChanged();
     }
 }

--- a/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementsModel.java
+++ b/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementsModel.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.alexfalappa.nbspringboot.navigator;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.swing.table.AbstractTableModel;
+
+/**
+ * A super simple table model for the navigator UI.
+ *
+ * @author Michael J. Simons, 2016-09-16
+ */
+public class MappedElementsModel extends AbstractTableModel {
+
+    private static final long serialVersionUID = 5870247061989235811L;
+
+    private final List<MappedElement> data = Collections.synchronizedList(new ArrayList<MappedElement>());
+
+    @Override
+    public String getColumnName(int column) {
+        String rv;
+        switch (column) {
+            case 0:
+                rv = "Resource URL";
+                break;
+            case 1:
+                rv = "Request Method";
+                break;
+            case 2:
+                rv = "Handler Method";
+                break;
+            default:
+                rv = null;
+        }
+        return rv;
+    }
+
+    @Override
+    public int getRowCount() {
+        return this.data.size();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return 3;
+    }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        final MappedElement mappedElement = this.data.get(rowIndex);
+        Object rv;
+        switch (columnIndex) {
+            case 0:
+                rv = mappedElement.getUrl();
+                break;
+            case 1:
+                rv = mappedElement.getMethod();
+                break;
+            case 2:
+                rv = mappedElement.getElement().toString();
+                break;
+            default:
+                rv = null;
+        }
+
+        return rv;
+    }
+
+    void refresh(final List<MappedElement> newData) {
+        this.data.clear();
+        this.data.addAll(newData);
+        this.fireTableDataChanged();
+    }
+}

--- a/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementsModel.java
+++ b/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementsModel.java
@@ -82,6 +82,10 @@ public class MappedElementsModel extends AbstractTableModel {
 
         return rv;
     }
+    
+    public MappedElement getElementAt(final int rowIndex) {
+        return this.data.get(rowIndex);
+    }
 
     void refresh(final List<MappedElement> newData) {
         final Runnable r = new Runnable() {

--- a/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementsModel.java
+++ b/src/main/java/com/github/alexfalappa/nbspringboot/navigator/MappedElementsModel.java
@@ -66,13 +66,13 @@ public class MappedElementsModel extends AbstractTableModel {
         Object rv;
         switch (columnIndex) {
             case 0:
-                rv = mappedElement.getUrl();
+                rv = mappedElement.getResourceUrl();
                 break;
             case 1:
-                rv = mappedElement.getMethod();
+                rv = mappedElement.getRequestMethod();
                 break;
             case 2:
-                rv = mappedElement.getElement().toString();
+                rv = mappedElement.getHandlerMethod();
                 break;
             default:
                 rv = null;

--- a/src/main/java/com/github/alexfalappa/nbspringboot/navigator/RequestMappingNavigatorPanel.java
+++ b/src/main/java/com/github/alexfalappa/nbspringboot/navigator/RequestMappingNavigatorPanel.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.alexfalappa.nbspringboot.navigator;
+
+import java.awt.BorderLayout;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import org.netbeans.spi.navigator.NavigatorPanel;
+import org.netbeans.spi.navigator.NavigatorPanel.Registration;
+import org.openide.loaders.DataObject;
+import org.openide.util.Lookup;
+import org.openide.util.NbBundle.Messages;
+
+/**
+ * The actual navigator UI.
+ *
+ * @author Michael J. Simons, 2016-09-14
+ */
+@Messages({
+    "displayName=Request Mappings",
+    "displayHint=Displays all @RequestMappings of the current *Controller",
+    "resourceUrl=Resource URL",
+    "requestMethod=Request Method",
+    "handlerMethod=Handler Method"
+})
+@Registration(mimeType = "text/x-java", displayName = "#displayName")
+public class RequestMappingNavigatorPanel implements NavigatorPanel {
+
+    /**
+     * template for finding data in given context. Object used as example,
+     * replace with your own data source, for example JavaDataObject etc
+     */
+    private static final Lookup.Template MY_DATA = new Lookup.Template(DataObject.class);
+
+    /**
+     * holds UI of this panel.
+     */
+    private final JComponent component;
+
+    private final ElementScanningTaskFactory mappedElementGatheringTaskFactory;
+
+    /**
+     * public no arg constructor needed for system to instantiate provider well
+     */
+    public RequestMappingNavigatorPanel() {
+        final MappedElementsModel mappedElementsModel = new MappedElementsModel();
+        this.mappedElementGatheringTaskFactory = new ElementScanningTaskFactory(mappedElementsModel);
+        final JTable table = new JTable(mappedElementsModel);
+        final JPanel panel = new JPanel();
+        panel.setLayout(new BorderLayout());
+        panel.add(new JScrollPane(table), BorderLayout.CENTER);
+        this.component = panel;
+    }
+
+    @Override
+    public String getDisplayHint() {
+        return Bundle.displayHint();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return Bundle.displayName();
+    }
+
+    @Override
+    public JComponent getComponent() {
+        return this.component;
+    }
+
+    @Override
+    public void panelActivated(Lookup context) {
+        this.mappedElementGatheringTaskFactory.activate();
+    }
+
+    @Override
+    public void panelDeactivated() {
+        this.mappedElementGatheringTaskFactory.deactivate();
+    }
+
+    @Override
+    public Lookup getLookup() {
+        return null;
+    }
+}

--- a/src/main/java/com/github/alexfalappa/nbspringboot/navigator/RequestMappingNavigatorPanel.java
+++ b/src/main/java/com/github/alexfalappa/nbspringboot/navigator/RequestMappingNavigatorPanel.java
@@ -31,6 +31,8 @@ import org.netbeans.spi.navigator.NavigatorPanel.Registration;
 import org.openide.cookies.EditorCookie;
 import org.openide.loaders.DataObject;
 import org.openide.util.Lookup;
+import org.openide.util.LookupEvent;
+import org.openide.util.LookupListener;
 import org.openide.util.NbBundle.Messages;
 
 /**
@@ -48,11 +50,19 @@ import org.openide.util.NbBundle.Messages;
 @Registration(mimeType = "text/x-java", displayName = "#displayName")
 public class RequestMappingNavigatorPanel implements NavigatorPanel {
 
+    /** Object used as example, replace with your own data source, for example JavaDataObject etc */
+    private static final Lookup.Template MY_DATA = new Lookup.Template(DataObject.class);
+    
     /**
      * holds UI of this panel.
      */
     private final JComponent component;
 
+    /** current context to work on. */
+    private Lookup.Result currentContext;
+    
+    private final LookupListener contextListener;
+    
     private final MappedElementsModel mappedElementsModel;
 
     private final ElementScanningTaskFactory mappedElementGatheringTaskFactory;
@@ -93,6 +103,12 @@ public class RequestMappingNavigatorPanel implements NavigatorPanel {
                 }
             }
         });
+        
+        this.contextListener = new LookupListener() {
+            @Override
+            public void resultChanged(LookupEvent le) {                
+            }            
+        };
     }
 
     @Override
@@ -112,12 +128,16 @@ public class RequestMappingNavigatorPanel implements NavigatorPanel {
 
     @Override
     public void panelActivated(Lookup context) {
+        this.currentContext = context.lookup(MY_DATA);
+        this.currentContext.addLookupListener(this.contextListener);
         this.mappedElementGatheringTaskFactory.activate();
     }
 
     @Override
     public void panelDeactivated() {
         this.mappedElementGatheringTaskFactory.deactivate();
+        this.currentContext.removeLookupListener(this.contextListener);
+        this.currentContext = null;
     }
 
     @Override


### PR DESCRIPTION
Hi Alessandro,

here's the promised pull request for #35.

I'd love to see this in your plugin, it would be of great value for me and me team.

## What works:

* If you open a Java source file and it's a Controller or RestController, than an entry inside the Navigator "Request Mappings" appears. It shows all @RequestMappings and derivations, as Spring would compute them. I've taken care that @RequestMapping at type level restricts the mappings at method level. The extractor won't complain about some invalid combinations as Spring would, though. 
* You can select an entry in the table and the editor is opened at the correct place
* the list is updated as soon as you change the source

## What i don't know

* I don't know if its the right way to watch for the source. I have another solution getting the content of the editor when the context changes, but that was as quick. But thats pretty much isolated in the panel and the ElementScanningTaskFactory. Everything else, including the ElementScanningTask can be used if you do a manual compile or source file task. The current context is already available in the panel.
* Anyway: The proposed solution waits for the background scanning of a freshly opened project, so the table stays empty or isn't updated.

## What doesn't work

I could manage to get the Request Mapping panel to the bottom of the list. I had an experimental project where this did work right out of the box. I would prefer not having them at the top but last. I guess it has something to do with the layer file, but that I could figure out.

![requestmappings](https://cloud.githubusercontent.com/assets/526383/18600098/00becce0-7c5c-11e6-8836-eae3de6454ea.jpg)
